### PR TITLE
add-shippingmethod-fillables

### DIFF
--- a/src/Picqer/Carriers/SendCloud/ShippingMethod.php
+++ b/src/Picqer/Carriers/SendCloud/ShippingMethod.php
@@ -23,6 +23,9 @@ class ShippingMethod extends Model
         'name',
         'carrier',
         'price',
+        'min_weight',
+        'max_weight',
+        'service_point_input',
         'options',
         'countries'
     ];


### PR DESCRIPTION
Added min_weight, max_weight and service_point_input fillables
to be up to date with the SendCloud API