### PR TITLE
adds total_insured_value to parcel attributes

### DIFF
--- a/src/Picqer/Carriers/SendCloud/Parcel.php
+++ b/src/Picqer/Carriers/SendCloud/Parcel.php
@@ -49,7 +49,8 @@ class Parcel extends Model
         'requestShipment',
         'order_number',
         'tracking_number',
-        'weight'
+        'weight',
+        'total_insured_value'
     ];
 
     protected $url = 'parcels';


### PR DESCRIPTION
total_insured_value is an optional parameter that can be used to increase the insurance coverage of a parcel.

There is some information on how to use this parameter here: https://docs.sendcloud.sc/api/v2/index.html#parcel-new