### PR TITLE
getShipperName function changed from private to public

### DIFF
--- a/src/Picqer/Carriers/SendCloud/Parcel.php
+++ b/src/Picqer/Carriers/SendCloud/Parcel.php
@@ -104,7 +104,7 @@ class Parcel extends Model
         }
     }
 
-    private function getShipperName()
+    public function getShipperName()
     {
         foreach ($this->shipperShippingMethodIds as $shipper => $methodIdArray) {
             if (in_array($this->shipment['id'], $methodIdArray)) {


### PR DESCRIPTION
Changed the getShipperName function in Picqer\Carriers\SendCloud\Parcel.php from private to public.

So we can call it through a Parcel object.