### PR TITLE
add "address_2" field to Parcel fillable fields

### DIFF
--- a/src/Picqer/Carriers/SendCloud/Parcel.php
+++ b/src/Picqer/Carriers/SendCloud/Parcel.php
@@ -37,6 +37,7 @@ class Parcel extends Model
         'company_name',
         'address',
         'address_divided',
+        'address_2',
         'city',
         'postal_code',
         'telephone',


### PR DESCRIPTION
Added an "address_2" field to the fillable property of Parcel class.
This allows to supply more details about the house number, f.e. the number of the postal box.

Sendcloud forces a max. limit of the house_number of 8 characters for some carriers. This makes generating labels for addresses like Kasteelstraat 1, bus 200A impossible as the house_number would be too long.