### PR TITLE
Add multiple

### DIFF
--- a/src/Picqer/Carriers/SendCloud/Parcel.php
+++ b/src/Picqer/Carriers/SendCloud/Parcel.php
@@ -32,6 +32,7 @@ class Parcel extends Model
 
     use Query\Findable;
     use Persistance\Storable;
+    use Persistance\Multiple;
 
     protected $fillable = [
         'id',

--- a/src/Picqer/Carriers/SendCloud/Persistance/Multiple.php
+++ b/src/Picqer/Carriers/SendCloud/Persistance/Multiple.php
@@ -1,0 +1,38 @@
+<?php
+
+namespace Picqer\Carriers\SendCloud\Persistance;
+
+use Picqer\Carriers\SendCloud\Connection;
+
+/**
+ * Trait Multiple
+ *
+ * @method Connection connection()
+ *
+ * @package Picqer\Carriers\SendCloud\Persistance
+ */
+trait Multiple
+{
+    public function saveMultiple(array $models)
+    {
+        $resultModels = [];
+        $results = $this->insertMultiple($models);
+        foreach ($results[$this->namespaces['plural']] as $result)
+        {
+            $resultModels[] = new static($this->connection(), $result);
+        }
+        return $resultModels;
+    }
+
+    public function insertMultiple(array $models)
+    {
+        $json = [];
+        $json[$this->namespaces['plural']] = [];
+        foreach ($models as $model)
+        {
+            $json[$this->namespaces['plural']][] = $model->attributes();
+        }
+
+        return $this->connection()->post($this->url, json_encode($json));
+    }
+}


### PR DESCRIPTION
Allows you to create multiple parcels or multiple items for other endpoints in the future.

Example:

```
$parcels = [];

for ($i = 1; $i <= 10; $i++)
{
	$parcel = $sendCloud->parcels();
        $parcel->name = 'John Smith';
	$parcel->company_name = 'ACME';
	$parcel->address = 'Wellingtonstreet 25';
	$parcel->city = 'Wellington';
	$parcel->postal_code = '3423 DD';
	$parcel->country = 'NL';
	$parcel->requestShipment = true;
	$parcel->shipment = 10;
	$parcel->order_number = 'ORDER2014-52321';
	$parcels[] = $parcel;
}

$parcels = $sendCloud->parcels()->saveMultiple($parcels);
```