### PR TITLE
Add isset support to model attributes

### DIFF
--- a/src/Picqer/Carriers/SendCloud/Model.php
+++ b/src/Picqer/Carriers/SendCloud/Model.php
@@ -115,6 +115,11 @@ abstract class Model
         return null;
     }
 
+    public function __isset($key)
+    {
+        return isset($this->attributes[$key]);
+    }
+
     public function __set($key, $value)
     {
         if ($this->isFillable($key)) {


### PR DESCRIPTION
The models in this library have dynamic attributes which can be retrieved via __get and __set. Currently, this does not work with any code that checks for the existence of those properties because `isset($model->attribute)` will always return false.

This PR fixes this by implementing the __isset function on models.