### PR TITLE
Adding house_number in Parcel

### DIFF
--- a/src/Picqer/Carriers/SendCloud/Parcel.php
+++ b/src/Picqer/Carriers/SendCloud/Parcel.php
@@ -9,6 +9,7 @@ namespace Picqer\Carriers\SendCloud;
  * @property string name
  * @property string company_name
  * @property string address
+ * @property string house_number
  * @property array address_divided
  * @property string city
  * @property string postal_code
@@ -38,6 +39,7 @@ class Parcel extends Model
         'id',
         'address',
         'address_2',
+        'house_number',
         'address_divided',
         'city',
         'company_name',


### PR DESCRIPTION
Documentation allow to add house_number in parcel https://docs.sendcloud.sc/api/v2/shipping/#create-a-parcel

If i'm missing something please let me know I will fix.