### PR TITLE
feat: Add more fields incl sender to Parcel

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ $parcel->postal_code = '3423 DD';
 $parcel->country = 'NL';
 $parcel->order_number = 'ORDER2014-52321';
 
-$parcel->request_label = true; // Specifically needed to create a shipment after adding the parcel
+$parcel->requestShipment = true; // Specifically needed to create a shipment after adding the parcel
 
 $parcel->save();
 ```
@@ -70,7 +70,7 @@ $parcel->from_city = 'Wellington';
 $parcel->from_postal_code = '3423 DD';
 $parcel->from_country = 'NL';
 
-$parcel->request_label = true; // Specifically needed to create a shipment after adding the parcel
+$parcel->requestShipment = true; // Specifically needed to create a shipment after adding the parcel
 
 $parcel->save();
 ```
@@ -122,7 +122,7 @@ $parcel->parcel_items = [
     ]
 ];
 
-$parcel->request_label = true; // Specifically needed to create a shipment after adding the parcel
+$parcel->requestShipment = true; // Specifically needed to create a shipment after adding the parcel
 
 $parcel->save();
 ```

--- a/src/Picqer/Carriers/SendCloud/Parcel.php
+++ b/src/Picqer/Carriers/SendCloud/Parcel.php
@@ -14,7 +14,7 @@ namespace Picqer\Carriers\SendCloud;
  * @property string city
  * @property string postal_code
  * @property string telephone
- * @property bool request_label
+ * @property bool requestShipment
  * @property string email
  * @property array data
  * @property array country
@@ -93,7 +93,7 @@ class Parcel extends Model
         'city',
         'postal_code',
         'telephone',
-        'request_label',
+        'requestShipment',
         'email',
         'data',
         'country',


### PR DESCRIPTION
minor:

- Changes the ordering of `@property` declarations to match the ordering on the Sendcloud API documentation 

feat:

- Adds sender_* fields
- Adds collo fields
- Adds Deutsche Post fields
- Adds customs fields (EORI, VAT)

break:

- Replaces `requestShipment` with `request_label` as is the format in the Sendcloud API