### PR TITLE
Add support for query options when inserting, updating or deleting models

### DIFF
--- a/src/Picqer/Carriers/SendCloud/Connection.php
+++ b/src/Picqer/Carriers/SendCloud/Connection.php
@@ -174,10 +174,15 @@ class Connection
             $resultArray = json_decode($responseBody, true);
 
             if (! is_array($resultArray)) {
-                throw new SendCloudApiException(sprintf('SendCloud error %s: %s', $response->getStatusCode(), $responseBody), $response->getStatusCode());
+                throw new SendCloudApiException(sprintf(
+                    'SendCloud error %s: %s',
+                    $response->getStatusCode(),
+                    $responseBody
+                ), $response->getStatusCode());
             }
 
-            if (array_key_exists('error', $resultArray)
+            if (
+                array_key_exists('error', $resultArray)
                 && is_array($resultArray['error'])
                 && array_key_exists('message', $resultArray['error'])
             ) {

--- a/src/Picqer/Carriers/SendCloud/Connection.php
+++ b/src/Picqer/Carriers/SendCloud/Connection.php
@@ -98,13 +98,14 @@ class Connection
      * Perform a POST request
      * @param string $url
      * @param mixed $body
+     * @param array $query
      * @return array
      * @throws SendCloudApiException
      */
-    public function post($url, $body): array
+    public function post($url, $body, $query = []): array
     {
         try {
-            $result = $this->client()->post($url, ['body' => $body]);
+            $result = $this->client()->post($url, ['body' => $body, 'query' => $query]);
             return $this->parseResponse($result);
         } catch (RequestException $e) {
             if ($e->hasResponse()) {
@@ -119,13 +120,14 @@ class Connection
      * Perform PUT request
      * @param string $url
      * @param mixed $body
+     * @param array $query
      * @return array
      * @throws SendCloudApiException
      */
-    public function put($url, $body): array
+    public function put($url, $body, $query = []): array
     {
         try {
-            $result = $this->client()->put($url, ['body' => $body]);
+            $result = $this->client()->put($url, ['body' => $body, 'query' => $query]);
             return $this->parseResponse($result);
         } catch (RequestException $e) {
             if ($e->hasResponse()) {
@@ -139,13 +141,14 @@ class Connection
     /**
      * Perform DELETE request
      * @param string $url
+     * @param array $query
      * @return array
      * @throws SendCloudApiException
      */
-    public function delete($url)
+    public function delete($url, $query = [])
     {
         try {
-            $result = $this->client()->delete($url);
+            $result = $this->client()->delete($url, ['query' => $query]);
             return $this->parseResponse($result);
         } catch (RequestException $e) {
             if ($e->hasResponse()) {
@@ -231,4 +234,3 @@ class Connection
         return $result->getBody()->getContents();
     }
 }
-

--- a/src/Picqer/Carriers/SendCloud/Persistance/Storable.php
+++ b/src/Picqer/Carriers/SendCloud/Persistance/Storable.php
@@ -13,29 +13,29 @@ use Picqer\Carriers\SendCloud\Connection;
  */
 trait Storable
 {
-    public function save()
+    public function save($options = [])
     {
         if ($this->exists()) {
-            $this->fill($this->update());
+            $this->fill($this->update($options));
         } else {
-            $this->fill($this->insert());
+            $this->fill($this->insert($options));
         }
 
         return $this;
     }
 
-    public function insert()
+    public function insert(array $options = [])
     {
-        return $this->connection()->post($this->url, $this->json());
+        return $this->connection()->post($this->url, $this->json(), $options);
     }
 
-    public function update()
+    public function update(array $options = [])
     {
-        return $this->connection()->put($this->url . '/' . urlencode($this->id), $this->json());
+        return $this->connection()->put($this->url . '/' . urlencode($this->id), $this->json(), $options);
     }
 
-    public function delete()
+    public function delete(array $options = [])
     {
-        return $this->connection()->delete($this->url . '/' . urlencode($this->id));
+        return $this->connection()->delete($this->url . '/' . urlencode($this->id), $options);
     }
 }


### PR DESCRIPTION
This PR adds support for additional options using query parameters when inserting, updating or deleting models using the SendCloud API. This change is useful when creating parcels and the `errors=verbose` or `errors=verbose-carrier` [query parameter flag](https://api.sendcloud.dev/docs/sendcloud-public-api/parcels-and-error-handling) needs to be used.