### PR TITLE
New: Added support for contracts in package

### DIFF
--- a/src/Picqer/Carriers/SendCloud/Contract.php
+++ b/src/Picqer/Carriers/SendCloud/Contract.php
@@ -1,0 +1,39 @@
+<?php
+
+namespace Picqer\Carriers\SendCloud;
+
+/**
+ * Class Contract
+ *
+ * @property integer id
+ * @property string client_id
+ * @property boolean is_active
+ * @property array carrier
+ * @property string name
+ * @property string country
+ * @property boolean is_default
+ *
+ * @package Picqer\Carriers\SendCloud
+ */
+class Contract extends Model
+{
+    use Query\Findable;
+
+    protected $fillable = [
+        'id',
+        'client_id',
+        'is_active',
+        'carrier',
+        'name',
+        'country',
+        'is_default',
+    ];
+
+    protected $url = 'contracts';
+
+    protected $namespaces = [
+        'singular' => 'contract',
+        'plural' => 'contracts'
+    ];
+
+}

--- a/src/Picqer/Carriers/SendCloud/Parcel.php
+++ b/src/Picqer/Carriers/SendCloud/Parcel.php
@@ -92,6 +92,7 @@ class Parcel extends Model
         'shipping_method_checkout_name',
         'requestShipment', // Special one to create new shipments
         'quantity',
+        'contract',
     ];
 
     protected $url = 'parcels';

--- a/src/Picqer/Carriers/SendCloud/SendCloud.php
+++ b/src/Picqer/Carriers/SendCloud/SendCloud.php
@@ -51,6 +51,11 @@ class SendCloud
         return new SenderAddress($this->connection);
     }
 
+    public function contracts(): Contract
+    {
+        return new Contract($this->connection);
+    }
+
     /**
      * SenderAddress Resource
      *


### PR DESCRIPTION
As documented in the Sendcloud API: https://api.sendcloud.dev/docs/sendcloud-public-api/parcels%2Foperations%2Fcreate-a-parcel, this PR adds support to retrieve contracts and set a contract when creating a shipment. 