### PR TITLE
Fix: Check response body size to not exceed maximum before json_decoding

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -19,7 +19,7 @@
         }
     ],
     "require": {
-        "php": ">=7.2.0",
+        "php": ">=7.4.0",
         "guzzlehttp/guzzle": "~6.0|~7.0",
         "ext-json": "*"
     },

--- a/src/Picqer/Carriers/SendCloud/Connection.php
+++ b/src/Picqer/Carriers/SendCloud/Connection.php
@@ -12,10 +12,10 @@ class Connection
     private string $apiUrl = 'https://panel.sendcloud.sc/api/v2/';
     private string $apiKey;
     private string $apiSecret;
-    private ?string $partnerId;
-    private ?int $maxResponseSizeInBytes;
+    private ?string $partnerId = null;
+    private ?int $maxResponseSizeInBytes = null;
 
-    private Client $client;
+    private ?Client $client = null;
     protected array $middleWares = [];
 
     public function __construct(string $apiKey, string $apiSecret, ?string $partnerId = null)
@@ -27,7 +27,7 @@ class Connection
 
     public function client(): Client
     {
-        if ($this->client) {
+        if ($this->client instanceof Client) {
             return $this->client;
         }
 
@@ -180,6 +180,11 @@ class Connection
     public function setMaxResponseSizeInBytes(?int $maxResponseSizeInBytes): void
     {
         $this->maxResponseSizeInBytes = $maxResponseSizeInBytes;
+    }
+
+    public function getMaxResponseSizeInBytes(): ?int
+    {
+        return $this->maxResponseSizeInBytes;
     }
 
     public function download($url, array $headers = ['Accept' => 'application/pdf']): string

--- a/src/Picqer/Carriers/SendCloud/Connection.php
+++ b/src/Picqer/Carriers/SendCloud/Connection.php
@@ -13,6 +13,7 @@ class Connection
     private $apiKey;
     private $apiSecret;
     private $partnerId;
+    private $maxResponseSizeInBytes;
 
     /**
      * Contains the HTTP client (Guzzle)
@@ -26,11 +27,12 @@ class Connection
      */
     protected $middleWares = [];
 
-    public function __construct(string $apiKey, string $apiSecret, ?string $partnerId = null)
+    public function __construct(string $apiKey, string $apiSecret, ?string $partnerId = null, ?int $maxResponseSizeInBytes = 50000000)
     {
         $this->apiKey = $apiKey;
         $this->apiSecret = $apiSecret;
         $this->partnerId = $partnerId;
+        $this->maxResponseSizeInBytes = $maxResponseSizeInBytes;
     }
 
     public function client(): Client
@@ -171,6 +173,11 @@ class Connection
             $response->getBody()->rewind();
 
             $responseBody = $response->getBody()->getContents();
+
+            if (strlen($responseBody) > $this->maxResponseSizeInBytes) {
+                throw new SendCloudApiException(sprintf('Response size exceeded maximum of %d bytes', $this->maxResponseSizeInBytes));
+            }
+
             $resultArray = json_decode($responseBody, true);
 
             if (! is_array($resultArray)) {

--- a/src/Picqer/Carriers/SendCloud/Connection.php
+++ b/src/Picqer/Carriers/SendCloud/Connection.php
@@ -23,7 +23,6 @@ class Connection
         $this->apiKey = $apiKey;
         $this->apiSecret = $apiSecret;
         $this->partnerId = $partnerId;
-        $this->maxResponseSizeInBytes = null;
     }
 
     public function client(): Client

--- a/src/Picqer/Carriers/SendCloud/Connection.php
+++ b/src/Picqer/Carriers/SendCloud/Connection.php
@@ -9,30 +9,21 @@ use Psr\Http\Message\ResponseInterface;
 
 class Connection
 {
-    private $apiUrl = 'https://panel.sendcloud.sc/api/v2/';
-    private $apiKey;
-    private $apiSecret;
-    private $partnerId;
-    private $maxResponseSizeInBytes;
+    private string $apiUrl = 'https://panel.sendcloud.sc/api/v2/';
+    private string $apiKey;
+    private string $apiSecret;
+    private ?string $partnerId;
+    private ?int $maxResponseSizeInBytes;
 
-    /**
-     * Contains the HTTP client (Guzzle)
-     * @var Client
-     */
-    private $client;
+    private Client $client;
+    protected array $middleWares = [];
 
-    /**
-     * Array of inserted middleWares
-     * @var array
-     */
-    protected $middleWares = [];
-
-    public function __construct(string $apiKey, string $apiSecret, ?string $partnerId = null, ?int $maxResponseSizeInBytes = 50000000)
+    public function __construct(string $apiKey, string $apiSecret, ?string $partnerId = null)
     {
         $this->apiKey = $apiKey;
         $this->apiSecret = $apiSecret;
         $this->partnerId = $partnerId;
-        $this->maxResponseSizeInBytes = $maxResponseSizeInBytes;
+        $this->maxResponseSizeInBytes = null;
     }
 
     public function client(): Client
@@ -65,7 +56,7 @@ class Connection
         return $this->client;
     }
 
-    public function insertMiddleWare($middleWare)
+    public function insertMiddleWare($middleWare): void
     {
         $this->middleWares[] = $middleWare;
     }
@@ -75,13 +66,6 @@ class Connection
         return $this->apiUrl;
     }
 
-    /**
-     * Perform a GET request
-     * @param string $url
-     * @param array $params
-     * @return array
-     * @throws SendCloudApiException
-     */
     public function get($url, $params = []): array
     {
         try {
@@ -96,14 +80,6 @@ class Connection
         }
     }
 
-    /**
-     * Perform a POST request
-     * @param string $url
-     * @param mixed $body
-     * @param array $query
-     * @return array
-     * @throws SendCloudApiException
-     */
     public function post($url, $body, $query = []): array
     {
         try {
@@ -118,14 +94,6 @@ class Connection
         }
     }
 
-    /**
-     * Perform PUT request
-     * @param string $url
-     * @param mixed $body
-     * @param array $query
-     * @return array
-     * @throws SendCloudApiException
-     */
     public function put($url, $body, $query = []): array
     {
         try {
@@ -140,14 +108,7 @@ class Connection
         }
     }
 
-    /**
-     * Perform DELETE request
-     * @param string $url
-     * @param array $query
-     * @return array
-     * @throws SendCloudApiException
-     */
-    public function delete($url, $query = [])
+    public function delete($url, $query = []): array
     {
         try {
             $result = $this->client()->delete($url, ['query' => $query]);
@@ -161,12 +122,7 @@ class Connection
         }
     }
 
-    /**
-     * @param ResponseInterface $response
-     * @return array Parsed JSON result
-     * @throws SendCloudApiException
-     */
-    public function parseResponse(ResponseInterface $response)
+    public function parseResponse(ResponseInterface $response): array
     {
         try {
             // Rewind the response (middlewares might have read it already)
@@ -174,8 +130,10 @@ class Connection
 
             $responseBody = $response->getBody()->getContents();
 
-            if (strlen($responseBody) > $this->maxResponseSizeInBytes) {
-                throw new SendCloudApiException(sprintf('Response size exceeded maximum of %d bytes', $this->maxResponseSizeInBytes));
+            if (! is_null($this->maxResponseSizeInBytes)) {
+                if (strlen($responseBody) > $this->maxResponseSizeInBytes) {
+                    throw new MaximumResponseSizeException(sprintf('Response size exceeded maximum of %d bytes', $this->maxResponseSizeInBytes));
+                }
             }
 
             $resultArray = json_decode($responseBody, true);
@@ -203,39 +161,29 @@ class Connection
     }
 
     /**
-     * Returns the selected environment
-     *
-     * @return string
      * @deprecated
      */
-    public function getEnvironment()
+    public function getEnvironment(): string
     {
         return 'live';
     }
 
     /**
-     * Set the environment for the client
-     *
-     * @param string $environment
-     * @throws SendCloudApiException
      * @deprecated
      */
-    public function setEnvironment($environment)
+    public function setEnvironment($environment): void
     {
         if ($environment === 'test') {
             throw new SendCloudApiException('SendCloud test environment is no longer available');
         }
     }
 
-    /**
-     * Download a resource.
-     *
-     * @param string $url
-     * @param array $headers
-     * @return string
-     * @throws SendCloudApiException
-     */
-    public function download($url, array $headers = ['Accept' => 'application/pdf'])
+    public function setMaxResponseSizeInBytes(?int $maxResponseSizeInBytes): void
+    {
+        $this->maxResponseSizeInBytes = $maxResponseSizeInBytes;
+    }
+
+    public function download($url, array $headers = ['Accept' => 'application/pdf']): string
     {
         try {
             $result = $this->client()->get($url, ['headers' => $headers]);

--- a/src/Picqer/Carriers/SendCloud/MaximumResponseSizeException.php
+++ b/src/Picqer/Carriers/SendCloud/MaximumResponseSizeException.php
@@ -1,0 +1,5 @@
+<?php
+
+namespace Picqer\Carriers\SendCloud;
+
+class MaximumResponseSizeException extends SendCloudApiException {}


### PR DESCRIPTION
In the `parseResponse` method we decode the response of the request. There is no check for the size of the response before decoding which could result in a memory allocation error. In this PR I've set a default of 50mb as maximum response size. If the response exceeds this limit, an exception is thrown. 
To provide flexibility for users of this package, the limit can be set when initialising the `Connection`. 