### PR TITLE
Add pagination to FindAll trait

### DIFF
--- a/src/Picqer/Carriers/SendCloud/Query/FindOne.php
+++ b/src/Picqer/Carriers/SendCloud/Query/FindOne.php
@@ -4,6 +4,7 @@ namespace Picqer\Carriers\SendCloud\Query;
 
 use Picqer\Carriers\SendCloud\Connection;
 use Picqer\Carriers\SendCloud\Model;
+use Picqer\Carriers\SendCloud\SendCloudApiException;
 
 /**
  * Trait FindOne
@@ -14,10 +15,10 @@ use Picqer\Carriers\SendCloud\Model;
  */
 trait FindOne
 {
-
     /**
      * @param $id
      * @return Model|FindOne
+     * @throws SendCloudApiException
      */
     public function find($id)
     {

--- a/src/Picqer/Carriers/SendCloud/Query/Findable.php
+++ b/src/Picqer/Carriers/SendCloud/Query/Findable.php
@@ -4,8 +4,6 @@ namespace Picqer\Carriers\SendCloud\Query;
 
 trait Findable
 {
-
     use FindOne;
     use FindAll;
-
 }


### PR DESCRIPTION
To get the first 100 pages of parcels, use:

```php
$parcels = $sendCloud->parcels()->all([], 100);
```

To get all pages of contracts, use:
```php
$parcels = $sendCloud->contracts()->all([], null);
```
