### PR TITLE
Fixed issue 52

### DIFF
--- a/src/Picqer/Carriers/SendCloud/Parcel.php
+++ b/src/Picqer/Carriers/SendCloud/Parcel.php
@@ -9,6 +9,7 @@ namespace Picqer\Carriers\SendCloud;
  * @property string $name
  * @property string $company_name
  * @property string $address
+ * @property string $address_2
  * @property string $house_number
  * @property array $address_divided
  * @property string $city


### PR DESCRIPTION
$address_2 not added as property #56 In Parcel.php $address_2 is not added as property preventing auto recognition in IDE