### PR TITLE
perf: Moved `array_merge` out of the loop when paginating results

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
+.DS_Store
+.idea
 composer.phar
 composer.lock
 vendor/

--- a/src/Picqer/Carriers/SendCloud/Query/FindAll.php
+++ b/src/Picqer/Carriers/SendCloud/Query/FindAll.php
@@ -21,11 +21,11 @@ trait FindAll
         while (true) {
             $result = $this->connection()->get($this->url, $params);
 
-            $allRecords = array_merge($allRecords, $this->collectionFromResult($result));
+            $allRecords[] = $this->collectionFromResult($result);
 
             if (! empty($result['next'])) {
                 // Get the querystring params from the next url, so we can retrieve the next page
-                $params = parse_url($result['next'], PHP_URL_QUERY);
+                $params = \parse_url($result['next'], PHP_URL_QUERY);
             } else {
                 // If no next page is found, all records are complete
                 break;
@@ -34,12 +34,12 @@ trait FindAll
             $pages++;
 
             // If max pages is set and reached, also stop the loop
-            if (! is_null($maxPages) && $pages >= $maxPages) {
+            if (null !== $maxPages && $pages >= $maxPages) {
                 break;
             }
         }
 
-        return $allRecords;
+        return \array_merge(...$allRecords);
     }
 
     public function collectionFromResult($result): array


### PR DESCRIPTION
Calling `array_merge` inside a loop will copy the entire array into memory on every iteration (`O(n)`), moving this out of the loop will make it `O(1)`, reducing memory usage.